### PR TITLE
Allow crossbreeding between demigryph variants

### DIFF
--- a/1.6/Defs/AnimalDefs/Demigryphs.xml
+++ b/1.6/Defs/AnimalDefs/Demigryphs.xml
@@ -169,6 +169,16 @@
                 <ExtremeDesert>0.01</ExtremeDesert> -->
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -395,6 +405,16 @@
                 <ExtremeDesert>0.01</ExtremeDesert> -->
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -620,6 +640,16 @@
                 <ExtremeDesert>0.03</ExtremeDesert>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -844,6 +874,16 @@
                 <ExtremeDesert>0.06</ExtremeDesert>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -1070,6 +1110,16 @@
                 <DankPyon_DarkForest MayRequire="DankPyon.Medieval.Overhaul">0.03</DankPyon_DarkForest>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -1296,6 +1346,16 @@
                 <DankPyon_DarkForest MayRequire="DankPyon.Medieval.Overhaul">0.01</DankPyon_DarkForest>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -1523,6 +1583,16 @@
                 <DankPyon_DarkForest MayRequire="DankPyon.Medieval.Overhaul">0.07</DankPyon_DarkForest>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -1749,6 +1819,16 @@
                 <DankPyon_DarkForest MayRequire="DankPyon.Medieval.Overhaul">0.03</DankPyon_DarkForest>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_JadeDemigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -1975,6 +2055,16 @@
                 <ExtremeDesert>0.01</ExtremeDesert>
       </wildBiomes>
       <lifeExpectancy>50</lifeExpectancy>
+      <canCrossBreedWith>
+        <li>pphhyy_Demigryph</li>
+        <li>pphhyy_CrimsonDemigryph</li>
+        <li>pphhyy_CheetahDemigryph</li>
+        <li>pphhyy_VultureDemigryph</li>
+        <li>pphhyy_LeopardDemigryph</li>
+        <li>pphhyy_PantherDemigryph</li>
+        <li>pphhyy_TigerDemigryph</li>
+        <li>pphhyy_Daermigryph</li>
+      </canCrossBreedWith>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>

--- a/Workshop/WorkshopDescription.bbcode.txt
+++ b/Workshop/WorkshopDescription.bbcode.txt
@@ -20,6 +20,7 @@ A powerful and majestic creature, the Demigryph was rumoured to be genetically c
 [b]Current features[/b]
 - 9 demigryph variants
 - Demigryph eggs and breeding
+- Crossbreeding between all demigryph variants
 - Demigryph leather, feathers, and claws
 - Human demigryph-themed helms
 - Demigryph banners
@@ -50,6 +51,7 @@ A powerful and majestic creature, the Demigryph was rumoured to be genetically c
 
 [b]What has been fixed and updated in the continued 1.6 version[/b]
 - Updated and maintained for RimWorld 1.6
+- Added crossbreeding support between all demigryph variants
 - Added proper demigryph shield implementation from the existing art assets
 - Fixed banner and shield storage/equip categorization issues
 - Fixed trophy item categorization for demigryph feathers and claws


### PR DESCRIPTION
## Summary
- allow all demigryph variants to crossbreed with each other
- use RimWorld's built-in crossbreeding lists in the active 1.6 race defs
- keep egg-layer behavior unchanged so offspring follow the female's egg type

## Notes
- this is a 1.6-only change
- no custom code required; this uses base RimWorld 1.6 mating behavior
